### PR TITLE
Switch to FTS index divided by document fields

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,5 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="EntryPointsManager">
+    <list size="3">
+      <item index="0" class="java.lang.String" itemvalue="org.openjdk.jmh.annotations.Benchmark" />
+      <item index="1" class="java.lang.String" itemvalue="org.openjdk.jmh.annotations.Setup" />
+      <item index="2" class="java.lang.String" itemvalue="org.openjdk.jmh.annotations.State" />
+    </list>
+  </component>
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="16" project-jdk-type="JavaSDK" />
 </project>

--- a/core/src/main/kotlin/FtsIndex.kt
+++ b/core/src/main/kotlin/FtsIndex.kt
@@ -47,16 +47,36 @@ internal typealias Token = String
 
 /**
  * Alias for a [Map] that maps a document token against frequencies of that token
- * in all documents.
+ * in all documents according to each property of the document
+ *
+ * Example:
+ * ```kotlin
+ * data class Doc(val name: String, val author: String)
+ * ```
+ * can be visualised as:
+ *
+ * ```json
+ * {
+ *   "<some-token>": {
+ *     "name": {
+ *       "<doc-id>": "<frequency>",
+ *     },
+ *     "author": {
+ *       "<doc-id>": "<frequency>"
+ *     }
+ *   }
+ * }
+ * ```
+ * ```
  */
-internal typealias InvertedIndex = Map<Token, DocumentFrequencies>
+internal typealias InvertedIndex = Map<Token, Map<String, DocumentFrequencies>>
 
 /**
  * Mutable variant of [InvertedIndex].
  *
  * Backed by a [PatriciaTrie] for efficient space utilisation.
  */
-internal typealias MutableInvertedIndex = Trie<Token, DocumentFrequencies>
+internal typealias MutableInvertedIndex = Trie<Token, MutableMap<String, DocumentFrequencies>>
 
 /**
  * A Full Text Search index for fast and efficient
@@ -117,7 +137,8 @@ public class FtsIndex<DocType : Any>(
      * 2. Converts each extracted property to its value as a string
      * 3. Runs the string value through the Text Processing [Pipeline] to extract tokens
      * from the document.
-     * 4. Add each token as a key to the index, with the value set to its document frequencies
+     * 4. Add each token as a key to the index, with the value set to its property
+     * specific document frequencies
      *
      * Returns without modifying the index if a document with the given ID is already
      * present in the index.
@@ -132,22 +153,28 @@ public class FtsIndex<DocType : Any>(
         }
 
         val docProps = extractProperties(doc)
-        val docTokens = docProps
-            .map { prop -> extractTokens(prop, pipeline) }
-            .flatten()
-
-        docTokens.forEach { token ->
-            val docFrequencies = _index[token] ?: mutableMapOf()
-            val tokenFrequency = docFrequencies.getOrDefault(docId, 0) + 1
-            docFrequencies[docId] = tokenFrequency
-
-            _index[token] = docFrequencies
+        val propsToTokens = docProps.associate { prop ->
+            val propValue = prop.call(doc)
+            val propTokens = extractTokens(propValue, pipeline)
+            prop.name to propTokens
         }
 
-        val docLength = docTokens.size
+        for ((prop, tokens) in propsToTokens) {
+            for (token in tokens) {
+                val propsForToken = _index[token] ?: mutableMapOf()
+                val docFrequenciesForProp = propsForToken[prop] ?: mutableMapOf()
+                val tokenFrequency = docFrequenciesForProp.getOrDefault(docId, 0) + 1
+
+                docFrequenciesForProp[docId] = tokenFrequency
+                propsForToken[prop] = docFrequenciesForProp
+                _index[token] = propsForToken
+            }
+        }
+
+        val docLength = propsToTokens.values.sumOf { tokens -> tokens.size }
         docs[docId] = docLength
 
-        return docTokens.size
+        return propsToTokens.size
     }
 
     /**
@@ -171,25 +198,39 @@ public class FtsIndex<DocType : Any>(
 
         val docProps = extractProperties(doc)
         val docTokens = docProps
-            .map { prop -> extractTokens(prop, pipeline) }
+            .map { prop ->
+                val propValue = prop.call(doc)
+                extractTokens(propValue, pipeline)
+            }
             .flatten()
 
         for (token in docTokens) {
-            val docFrequencies = _index[token]
-            if (docFrequencies == null || docFrequencies.isEmpty()) {
+            val tokenProps = _index[token]
+            if (tokenProps == null || tokenProps.isEmpty()) {
                 _index.remove(token)
                 continue
             }
 
-            val existingFrequency = docFrequencies.getOrDefault(docId, 0)
-            val newFrequency = existingFrequency - 1
-            docFrequencies[docId] = newFrequency
+            val propsToRemove = mutableListOf<String>()
+            for ((prop, documentFrequencies) in tokenProps) {
+                val existingFrequency = documentFrequencies.getOrDefault(docId, 0)
+                val newFrequency = existingFrequency - 1
+                documentFrequencies[docId] = newFrequency
 
-            if (newFrequency < 1) {
-                docFrequencies.remove(docId)
+                if (newFrequency < 1) {
+                    documentFrequencies.remove(docId)
+                }
+
+                if (documentFrequencies.isEmpty()) {
+                    propsToRemove.add(prop)
+                }
             }
 
-            if (docFrequencies.isEmpty()) {
+            for (prop in propsToRemove) {
+                tokenProps.remove(prop)
+            }
+
+            if (tokenProps.isEmpty()) {
                 _index.remove(token)
             }
         }
@@ -215,11 +256,13 @@ public class FtsIndex<DocType : Any>(
 
         val results = mutableListOf<SearchResult>()
         for (queryToken in queryTokens) {
-            val matchingDocs = _index[queryToken] ?: continue
-            for (docId in matchingDocs.keys) {
-                val score = score(queryToken, docId)
-                val result = SearchResult(docId, score, queryToken)
-                results.add(result)
+            val matchingProps = _index[queryToken] ?: continue
+            for ((prop, docFrequencies) in matchingProps) {
+                for (docId in docFrequencies.keys) {
+                    val score = score(queryToken, docId, prop)
+                    val result = SearchResult(docId, score, queryToken)
+                    results.add(result)
+                }
             }
         }
 
@@ -243,10 +286,10 @@ public class FtsIndex<DocType : Any>(
      * @param docId The document in which the term appears
      * @return The TF-IDF value for the term in the document
      */
-    private fun score(term: String, docId: Int): Double {
+    private fun score(term: String, docId: Int, prop: String): Double {
         val docLength = docs[docId] ?: 0
-        val tf = termFrequency(term, docId, docLength, _index)
-        val df = documentFrequency(term, _index)
+        val tf = termFrequency(term, docId, docLength, _index, prop)
+        val df = documentFrequency(term, _index, prop)
         val n = docs.size
         return tfIdf(tf, df, n)
     }

--- a/core/src/main/kotlin/rank/TfIdf.kt
+++ b/core/src/main/kotlin/rank/TfIdf.kt
@@ -15,6 +15,7 @@ import kotlin.math.ln
  * @param docId The document to find the term's frequency in
  * @param docLength The length of the tokens in the document
  * @param index The FTS index
+ * @param prop The name of the document property to fetch document frequencies for
  * @return The scaled frequency of the term in the document
  */
 internal fun termFrequency(
@@ -22,8 +23,10 @@ internal fun termFrequency(
     docId: Int,
     docLength: Int,
     index: InvertedIndex,
+    prop: String,
 ): Double {
-    val docsWithTerm = index[term] ?: return 0.0
+    val propsWithTerm = index[term] ?: return 0.0
+    val docsWithTerm = propsWithTerm[prop] ?: return 0.0
     val rawTf = docsWithTerm[docId] ?: return 0.0
     return rawTf.toDouble() / docLength
 }
@@ -36,13 +39,16 @@ internal fun termFrequency(
  *
  * @param term The term to find the document frequency of
  * @param index The FTS index
+ * @param prop The prop to fetch docs for
  * @return The number of documents in which the term appears
  */
 internal fun documentFrequency(
     term: String,
     index: InvertedIndex,
+    prop: String,
 ): Int {
-    val docsWithTerm = index[term] ?: return 0
+    val propsWithTerm = index[term] ?: return 0
+    val docsWithTerm = propsWithTerm[prop] ?: return 0
     return docsWithTerm.keys.size
 }
 

--- a/core/src/test/kotlin/FtsIndexTest.kt
+++ b/core/src/test/kotlin/FtsIndexTest.kt
@@ -79,7 +79,11 @@ class FtsIndexTest : DescribeSpec({
             val books = generateBooks().take(10).toList()
             books.forEach { fts.add(it) }
 
-            val docIds = fts.index.values.map { docFreq -> docFreq.keys }.flatten().toSet()
+            val docIds = fts.index.values
+                .flatMap { propDocs -> propDocs.values }
+                .flatMap { docFreqs -> docFreqs.keys }
+                .toSet()
+
             docIds shouldContainExactlyInAnyOrder books.map { b -> b.id }
         }
 

--- a/core/src/test/kotlin/rank/TfIdfTest.kt
+++ b/core/src/test/kotlin/rank/TfIdfTest.kt
@@ -18,7 +18,8 @@ class TfIdfTest : DescribeSpec({
                 term = "michael",
                 docId = sentence.line,
                 docLength = sentenceTokens.size,
-                index = index.index
+                index = index.index,
+                sentence::value.name,
             )
             tf shouldBe 1.0 / sentenceTokens.size
         }
@@ -33,7 +34,8 @@ class TfIdfTest : DescribeSpec({
                 term = "toto",
                 docId = sentence.line,
                 docLength = sentenceTokens.size,
-                index = index.index
+                index = index.index,
+                sentence::value.name,
             )
             tf shouldBe 0.0
         }
@@ -48,7 +50,8 @@ class TfIdfTest : DescribeSpec({
                 term = "michael",
                 docId = sentence.line + 1,
                 docLength = sentenceTokens.size,
-                index = index.index
+                index = index.index,
+                sentence::value.name,
             )
             tf shouldBe 0.0
         }
@@ -61,7 +64,7 @@ class TfIdfTest : DescribeSpec({
                 add(Sentence(line = 1, "Michael have you received my email?"))
             }
 
-            val freq = documentFrequency("michael", index.index)
+            val freq = documentFrequency("michael", index.index, Sentence::value.name)
             freq shouldBe 2
         }
 
@@ -71,7 +74,7 @@ class TfIdfTest : DescribeSpec({
                 add(Sentence(line = 1, "Michael have you received my email?"))
             }
 
-            val freq = documentFrequency("toto", index.index)
+            val freq = documentFrequency("toto", index.index, Sentence::value.name)
             freq shouldBe 0
         }
     }

--- a/ir/src/main/kotlin/DocumentProcessing.kt
+++ b/ir/src/main/kotlin/DocumentProcessing.kt
@@ -3,6 +3,7 @@ package com.haroldadmin.lucilla.ir
 import com.haroldadmin.lucilla.annotations.Id
 import com.haroldadmin.lucilla.annotations.Ignore
 import com.haroldadmin.lucilla.pipeline.Pipeline
+import kotlin.reflect.KProperty
 import kotlin.reflect.full.declaredMemberProperties
 import kotlin.reflect.full.declaredMembers
 import kotlin.reflect.full.hasAnnotation
@@ -60,11 +61,13 @@ public fun <T : Any> extractDocumentId(doc: T): Int {
  * @param doc The document to extract properties from
  * @return Values of extracted properties from the document
  */
-public fun <T : Any> extractProperties(doc: T): List<String> {
-    return doc::class.declaredMemberProperties
+public fun <T : Any> extractProperties(doc: T): List<KProperty<String>> {
+    val stringProps = doc::class.declaredMemberProperties
         .filterNot { prop -> prop.hasAnnotation<Id>() || prop.hasAnnotation<Ignore>() }
         .filter { prop -> prop.returnType.isSubtypeOf(StringType) }
-        .mapNotNull { prop -> prop.call(doc) as? String }
+
+    @Suppress("UNCHECKED_CAST")
+    return stringProps as List<KProperty<String>>
 }
 
 /**

--- a/ir/src/test/kotlin/DocumentProcessingTest.kt
+++ b/ir/src/test/kotlin/DocumentProcessingTest.kt
@@ -73,44 +73,51 @@ class DocumentProcessingTest : DescribeSpec({
         it("should extract all relevant properties from a document") {
             data class Doc(val name: String, val author: String)
 
-            val props = extractProperties(Doc("Foo", "Bar"))
+            val doc = Doc("Foo", "Bar")
+            val props = extractProperties(doc).map { prop -> prop.call(doc) }
             props shouldContainExactlyInAnyOrder listOf("Foo", "Bar")
         }
 
         it("should ignore properties marked with @Ignore") {
             data class Doc(val name: String, @Ignore val author: String)
 
-            val props = extractProperties(Doc("Foo", "Bar"))
+            val doc = Doc("Foo", "Bar")
+            val props = extractProperties(doc).map { prop -> prop.call(doc) }
             props shouldContainExactly listOf("Foo")
         }
 
         it("should ignore properties that are not Strings") {
             data class Doc(val name: String, val year: Int)
 
-            val props = extractProperties(Doc("Foo", 2022))
+            val doc = Doc("Foo", 2022)
+            val props = extractProperties(doc).map { prop -> prop.call(doc) }
             props shouldContainExactly listOf("Foo")
         }
 
         it("should ignore member functions") {
             data class Doc(val name: String, val author: String) {
+                @Suppress("unused")
                 fun formattedName() = "$name $author"
             }
 
-            val props = extractProperties(Doc("Foo", "Bar"))
+            val doc = Doc("Foo", "Bar")
+            val props = extractProperties(doc).map { prop -> prop.call(doc) }
             props shouldContainExactlyInAnyOrder listOf("Foo", "Bar")
         }
 
         it("should ignore null properties") {
             data class Doc(val name: String?)
 
-            val props = extractProperties(Doc(null))
+            val doc = Doc(null)
+            val props = extractProperties(doc)
             props shouldHaveSize 0
         }
 
         it("should ignore properties marked with @Id") {
             data class Doc(@Id val id: String, val name: String)
 
-            val props = extractProperties(Doc("Foo", "Bar"))
+            val doc = Doc("Foo", "Bar")
+            val props = extractProperties(doc).map { prop -> prop.call(doc) }
             props shouldContainExactly listOf("Bar")
         }
     }


### PR DESCRIPTION
This change allows the FTS index to index data per document property.

- Index changes from `Map<String, Map<Int, Int>` (token to document frequencies) - to `Map<String, Map<String, Map<Int, Int>>` (token to property based document frequencies).
- Store property-based document lengths for scoring.
- Benchmarks confirm no noticeable loss of performance.
- Unit tests confirm no loss of functionality.

Fixes #3.
