### PR TITLE
Switch to positional postings list based FTS index

### DIFF
--- a/core/src/main/kotlin/rank/TfIdf.kt
+++ b/core/src/main/kotlin/rank/TfIdf.kt
@@ -1,56 +1,6 @@
 package com.haroldadmin.lucilla.core.rank
 
-import com.haroldadmin.lucilla.core.InvertedIndex
 import kotlin.math.ln
-
-/**
- * Calculates the frequency of the term in the document with the given ID
- *
- * This method uses the "scaled frequency" variant of the term-frequency metric.
- * - Raw frequency is the number of times the term appears in the document.
- * - Scaled frequency adjusts for the raw frequency by dividing it with the length of the
- * document
- *
- * @param term The term to find the frequency of
- * @param docId The document to find the term's frequency in
- * @param docLength The length of the tokens in the document
- * @param index The FTS index
- * @param prop The name of the document property to fetch document frequencies for
- * @return The scaled frequency of the term in the document
- */
-internal fun termFrequency(
-    term: String,
-    docId: Int,
-    docLength: Int,
-    index: InvertedIndex,
-    prop: String,
-): Double {
-    val propsWithTerm = index[term] ?: return 0.0
-    val docsWithTerm = propsWithTerm[prop] ?: return 0.0
-    val rawTf = docsWithTerm[docId] ?: return 0.0
-    return rawTf.toDouble() / docLength
-}
-
-/**
- * Returns the number of documents in which a term appears
- *
- * This method finds only the documents containing the exact term. Documents
- * that contain words with the given term as a prefix are not considered.
- *
- * @param term The term to find the document frequency of
- * @param index The FTS index
- * @param prop The prop to fetch docs for
- * @return The number of documents in which the term appears
- */
-internal fun documentFrequency(
-    term: String,
-    index: InvertedIndex,
-    prop: String,
-): Int {
-    val propsWithTerm = index[term] ?: return 0
-    val docsWithTerm = propsWithTerm[prop] ?: return 0
-    return docsWithTerm.keys.size
-}
 
 /**
  * Calculates the TF-IDF value for a term.
@@ -65,5 +15,21 @@ internal fun documentFrequency(
  * @return TF-IDF value for the term
  */
 internal fun tfIdf(tf: Double, df: Int, n: Int): Double {
+    return tf * (ln(n.toDouble() / (1 + df)))
+}
+
+/**
+ * Calculates the TF-IDF value for a term.
+ *
+ * This method uses the logarithmic IDF variant.
+ * The denominator is adjusted to be (1 + df) to avoid division
+ * by zero errors.
+ *
+ * @param tf The term frequency in a document
+ * @param df The number of documents in which the term appears
+ * @param n The number of documents in the index
+ * @return TF-IDF value for the term
+ */
+internal fun tfIdf(tf: Int, df: Int, n: Int): Double {
     return tf * (ln(n.toDouble() / (1 + df)))
 }

--- a/core/src/test/kotlin/FtsIndexTest.kt
+++ b/core/src/test/kotlin/FtsIndexTest.kt
@@ -79,12 +79,7 @@ class FtsIndexTest : DescribeSpec({
             val books = generateBooks().take(10).toList()
             books.forEach { fts.add(it) }
 
-            val docIds = fts.index.values
-                .flatMap { propDocs -> propDocs.values }
-                .flatMap { docFreqs -> docFreqs.keys }
-                .toSet()
-
-            docIds shouldContainExactlyInAnyOrder books.map { b -> b.id }
+            fts.docs shouldContainExactlyInAnyOrder books.map { b -> b.id }
         }
 
         it("should throw an error when adding a document with no '@Id' annotated element") {

--- a/core/src/test/kotlin/rank/TfIdfTest.kt
+++ b/core/src/test/kotlin/rank/TfIdfTest.kt
@@ -1,84 +1,9 @@
 package com.haroldadmin.lucilla.core.rank
 
-import com.haroldadmin.lucilla.core.Sentence
-import com.haroldadmin.lucilla.core.useFts
 import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.core.spec.style.DescribeSpec
-import io.kotest.matchers.shouldBe
 
 class TfIdfTest : DescribeSpec({
-    describe("Term Frequency") {
-        it("should return correct scaled term frequency for a document") {
-            val index = useFts<Sentence>()
-            val sentence = Sentence(line = 0, value = "No Michael no! This is so not right.")
-            index.add(sentence)
-
-            val sentenceTokens = index.pipeline.process(sentence.value)
-            val tf = termFrequency(
-                term = "michael",
-                docId = sentence.line,
-                docLength = sentenceTokens.size,
-                index = index.index,
-                sentence::value.name,
-            )
-            tf shouldBe 1.0 / sentenceTokens.size
-        }
-
-        it("should return 0 if the term does not exist in the document") {
-            val index = useFts<Sentence>()
-            val sentence = Sentence(line = 0, value = "No Michael no! This is so not right.")
-            index.add(sentence)
-
-            val sentenceTokens = index.pipeline.process(sentence.value)
-            val tf = termFrequency(
-                term = "toto",
-                docId = sentence.line,
-                docLength = sentenceTokens.size,
-                index = index.index,
-                sentence::value.name,
-            )
-            tf shouldBe 0.0
-        }
-
-        it("should return 0 if the document does not exist") {
-            val index = useFts<Sentence>()
-            val sentence = Sentence(line = 0, value = "No Michael no! This is so not right.")
-            index.add(sentence)
-
-            val sentenceTokens = index.pipeline.process(sentence.value)
-            val tf = termFrequency(
-                term = "michael",
-                docId = sentence.line + 1,
-                docLength = sentenceTokens.size,
-                index = index.index,
-                sentence::value.name,
-            )
-            tf shouldBe 0.0
-        }
-    }
-
-    describe("Document Frequency") {
-        it("should return correct DF for a token in a single document") {
-            val index = useFts<Sentence>().apply {
-                add(Sentence(line = 0, "Michael I have sent you an email"))
-                add(Sentence(line = 1, "Michael have you received my email?"))
-            }
-
-            val freq = documentFrequency("michael", index.index, Sentence::value.name)
-            freq shouldBe 2
-        }
-
-        it("should return 0 if the term does not exist") {
-            val index = useFts<Sentence>().apply {
-                add(Sentence(line = 0, "Michael I have sent you an email"))
-                add(Sentence(line = 1, "Michael have you received my email?"))
-            }
-
-            val freq = documentFrequency("toto", index.index, Sentence::value.name)
-            freq shouldBe 0
-        }
-    }
-
     describe("Inverse Document Frequency") {
         it("should not return an error if document frequency is 0") {
             shouldNotThrowAny { tfIdf(1.0, 0, 1) }

--- a/ir/src/main/kotlin/Posting.kt
+++ b/ir/src/main/kotlin/Posting.kt
@@ -1,0 +1,19 @@
+package com.haroldadmin.lucilla.ir
+
+/**
+ * A Posting records information about a token in a document's property.
+ *
+ * A posting is specific to every token in every property of every document.
+ * It's fundamental unit of information in an FTS index. It stores the following
+ * info:
+ * - ID of the document
+ * - Length of the property of the document
+ * - Offsets of the token in property's tokens. The number of positions
+ * is also its term frequency in the document.
+ */
+public data class Posting(
+    val docId: Int,
+    val property: String,
+    val propertyLength: Int,
+    val offsets: List<Int>,
+)


### PR DESCRIPTION
Switch to positional postings list based FTS index

- Add a new `Posting` class that stores index information for a token, including the document ID, property name, property length, and positional offsets
- Add IR functions to extract postings from a document
- Modify the scoring algorithm to use postings

The search result scoring algorithm is non-optimal currently, as it does not take advantage of property specific searching or proximity boosts.
Improvements for this are planned in future releases.

Fixes #5
