### PR TITLE
Add levenshtein distance implementation

### DIFF
--- a/benchmarks/src/main/kotlin/LevenshteinDistanceBenchmark.kt
+++ b/benchmarks/src/main/kotlin/LevenshteinDistanceBenchmark.kt
@@ -1,0 +1,15 @@
+package com.haroldadmin.lucilla.benchmarks
+
+import com.haroldadmin.lucilla.core.rank.ld
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.infra.Blackhole
+
+@State(Scope.Benchmark)
+class LevenshteinDistanceBenchmark {
+    @Benchmark
+    fun ldBenchmark(blackHole: Blackhole) {
+        blackHole.consume(ld("levenshtein", "edit"))
+    }
+}

--- a/core/src/main/kotlin/rank/LevenshteinDistance.kt
+++ b/core/src/main/kotlin/rank/LevenshteinDistance.kt
@@ -1,0 +1,57 @@
+package com.haroldadmin.lucilla.core.rank
+
+/**
+ * Calculates the Edit Distance (Levenshtein Distance) between
+ * the given Strings.
+ *
+ * @param a The first string
+ * @param b The second string
+ * @param deletionCost The cost of a deletion operation
+ * @param insertionCost The cost of an insertion operation
+ * @param replacementCost The cost of a replacement operation
+ */
+public fun ld(
+    a: String,
+    b: String,
+    deletionCost: Int = 1,
+    insertionCost: Int = 1,
+    replacementCost: Int = 1,
+): Int {
+    if (a.isEmpty()) {
+        return b.length
+    }
+
+    if (b.isEmpty()) {
+        return a.length
+    }
+
+    val dpTable: Array<IntArray> = Array(a.length + 1) {
+        IntArray(b.length + 1)
+    }
+
+    for (i in 1..a.length) {
+        dpTable[i][0] = i
+    }
+    for (i in 1..b.length) {
+        dpTable[0][i] = i
+    }
+
+    for (i in 1..a.length) {
+        val aChar = a[i - 1]
+        for (j in 1..b.length) {
+            val bChar = b[j - 1]
+            if (aChar == bChar) {
+                val editCost = dpTable[i - 1][j - 1]
+                dpTable[i][j] = editCost
+                continue
+            }
+
+            val costWithReplacement = dpTable[i - 1][j - 1] + replacementCost
+            val costWithDeletion = dpTable[i][j - 1] + deletionCost
+            val costWithInsertion = dpTable[i - 1][j] + insertionCost
+            dpTable[i][j] = minOf(costWithReplacement, costWithDeletion, costWithInsertion)
+        }
+    }
+
+    return dpTable[a.length][b.length]
+}

--- a/core/src/test/kotlin/rank/LevenshteinDistanceTest.kt
+++ b/core/src/test/kotlin/rank/LevenshteinDistanceTest.kt
@@ -1,0 +1,26 @@
+package com.haroldadmin.lucilla.core.rank
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+
+class LevenshteinDistanceTest : DescribeSpec({
+    it("should return 0 if the strings are empty") {
+        val distance = ld("", "")
+        distance shouldBe 0
+    }
+
+    it("should return 0 if the strings are the same") {
+        val distance = ld("foo", "foo")
+        distance shouldBe 0
+    }
+
+    it("should return the correct distance when one of the strings is empty") {
+        val distance = ld("foo", "")
+        distance shouldBe 3
+    }
+
+    it("should return the correct distance when both strings are non-empty") {
+        val distance = ld("ephrem", "benyam")
+        distance shouldBe 5
+    }
+})


### PR DESCRIPTION
This PR adds a utility function `ld` to calculate the Levenshtein Distance between two strings.
It supports customizable weights for replace/delete/insert operations.

This will be useful for the sorting the results of the upcoming autocomplete suggestions feature.

