### PR TITLE
Add support for autocompletion suggestions

### DIFF
--- a/core/src/main/kotlin/FtsIndex.kt
+++ b/core/src/main/kotlin/FtsIndex.kt
@@ -279,7 +279,7 @@ public class FtsIndex<DocType : Any>(
             .fold(mutableListOf<AutocompleteSuggestion>()) { suggestions, prefixKey ->
                 val score = ld(query, prefixKey).toDouble() / prefixKey.length
                 val suggestion = AutocompleteSuggestion(score, prefixKey)
-                suggestions.apply { add(suggestion)}
+                suggestions.apply { add(suggestion) }
             }
 
         suggestions.sortByDescending { it.score }

--- a/core/src/test/kotlin/App.kt
+++ b/core/src/test/kotlin/App.kt
@@ -12,17 +12,47 @@ fun main() {
     }
     println("index:complete ($timeToBuildIndex ms)")
 
-    do {
-        println("Enter search query (EXIT to stop)")
+    println("s: search, a: autocompletion suggestions")
+    when (readln().trim().lowercase()) {
+        "s"-> search(index, books)
+        "a" -> autocomplete(index, books)
+        else -> println("Invalid input")
+    }
+}
+
+fun search(index: FtsIndex<Book>, data: Map<Int, Book>) {
+    println("Search")
+    println("Enter search query (EXIT to stop)")
+    while(true) {
         val query = readln()
+        if (query == "EXIT") {
+            break
+        }
+
         println("Searching for '$query'")
-        var results: List<SearchResult>
+        val results: List<SearchResult>
         val searchTime = measureTimeMillis { results = index.search(query) }
         println("${results.size} results, $searchTime ms")
 
         results.forEachIndexed { i, result ->
-            val book = books[result.documentId]!!
+            val book = data[result.documentId]!!
             println("$i\t(${result.score}, ${result.matchTerm})\t${book.title}, ${book.author}")
         }
-    } while (query != "EXIT")
+    }
+}
+
+fun autocomplete(index: FtsIndex<Book>, data: Map<Int, Book>) {
+    println("Autocomplete Suggestions")
+    println("Enter search query (EXIT TO STOP)")
+    while(true) {
+        val query = readln()
+        if (query == "EXIT") {
+            break
+        }
+
+        println("Suggestions for '$query'")
+        val suggestions: List<AutocompleteSuggestion>
+        val searchTime = measureTimeMillis { suggestions = index.autocomplete(query) }
+        println("($searchTime ms) ${suggestions.joinToString { it.suggestion }}")
+    }
 }

--- a/core/src/test/kotlin/App.kt
+++ b/core/src/test/kotlin/App.kt
@@ -14,7 +14,7 @@ fun main() {
 
     println("s: search, a: autocompletion suggestions")
     when (readln().trim().lowercase()) {
-        "s"-> search(index, books)
+        "s" -> search(index, books)
         "a" -> autocomplete(index, books)
         else -> println("Invalid input")
     }
@@ -23,7 +23,7 @@ fun main() {
 fun search(index: FtsIndex<Book>, data: Map<Int, Book>) {
     println("Search")
     println("Enter search query (EXIT to stop)")
-    while(true) {
+    while (true) {
         val query = readln()
         if (query == "EXIT") {
             break
@@ -44,7 +44,7 @@ fun search(index: FtsIndex<Book>, data: Map<Int, Book>) {
 fun autocomplete(index: FtsIndex<Book>, data: Map<Int, Book>) {
     println("Autocomplete Suggestions")
     println("Enter search query (EXIT TO STOP)")
-    while(true) {
+    while (true) {
         val query = readln()
         if (query == "EXIT") {
             break

--- a/core/src/test/kotlin/FtsIndexTest.kt
+++ b/core/src/test/kotlin/FtsIndexTest.kt
@@ -125,4 +125,21 @@ class FtsIndexTest : DescribeSpec({
             fts.search("test") shouldHaveSize 0
         }
     }
+
+    context("Autocomplete suggestions") {
+        it("should return zero results if there are no matches") {
+            val index = useFts<Book>()
+            val results = index.autocomplete("foo")
+            results shouldHaveSize 0
+        }
+
+        it("should return matching results") {
+            val index = useFts<Sentence>()
+            index.add(Sentence(0, "football"))
+            index.add(Sentence(1, "foil"))
+
+            val results = index.autocomplete("fo")
+            results shouldHaveSize 2
+        }
+    }
 })


### PR DESCRIPTION
This PR adds the ability to query the FTS index for autocompletion suggestions.

- Uses prefix search to find keys with the input query as a prefix
- Each prefix result is treated as a suggestion
- The suggestions are ranked by their levenshtein distance from the query, normalized by the suggestion length

Autocompletion suggestions might be unexpected with a text processing pipeline that includes stemming as a part of it.

Fixes #8 

