### PR TITLE
Add ability to restrict search to selected props

### DIFF
--- a/core/src/main/kotlin/AutocompleteSuggestion.kt
+++ b/core/src/main/kotlin/AutocompleteSuggestion.kt
@@ -1,0 +1,17 @@
+package com.haroldadmin.lucilla.core
+
+/**
+ * A autocompletion suggestion for a search query
+ */
+public data class AutocompleteSuggestion(
+    /**
+     * Score of the autocompletion suggestion.
+     * Higher score implies more relevance.
+     */
+    val score: Double,
+
+    /**
+     * The autocompletion suggestion
+     */
+    val suggestion: String,
+)

--- a/core/src/main/kotlin/SearchQuery.kt
+++ b/core/src/main/kotlin/SearchQuery.kt
@@ -1,0 +1,72 @@
+package com.haroldadmin.lucilla.core
+
+import kotlin.reflect.KProperty
+
+/**
+ * A search query with various options to customise how to
+ * search the index and order results.
+ */
+public data class SearchQuery(
+    val text: String,
+    val selectProps: Set<String>? = null,
+)
+
+/**
+ * Builder for [SearchQuery].
+ *
+ * Serves as the backing class for the DSL to build a search
+ * query using [buildQuery].
+ */
+public class SearchQueryBuilder(
+    private val text: String
+) {
+    /**
+     * A null value indicates all indexed properties must be searched
+     */
+    private var selectProps: MutableSet<String>? = null
+
+    /**
+     * Specify which document properties to consider when searching
+     * the index.
+     *
+     * Only the documents that match the search query within the selected
+     * properties will be returned as a part of search results.
+     *
+     * The properties must be a part of the document type being indexed,
+     * and must not be annotated with [com.haroldadmin.lucilla.annotations.Ignore].
+     * Kotlin's type system is not flexible enough yet to restrict [props] to
+     * a specific class's properties.
+     *
+     * @param props The properties to search within
+     * @return The current builder instance
+     */
+    public fun select(vararg props: KProperty<String>): SearchQueryBuilder {
+        val propNames = props.map { it.name }
+        if (selectProps == null) {
+            selectProps = propNames.toMutableSet()
+        } else {
+            propNames.forEach { selectProps?.add(it) }
+        }
+        return this
+    }
+
+    /**
+     * Returns a finalized search query.
+     *
+     * @return Finalized search query
+     */
+    public fun build(): SearchQuery {
+        return SearchQuery(text, selectProps)
+    }
+}
+
+/**
+ * DSL initializer for building a search query using [SearchQueryBuilder].
+ *
+ * @param text The search query text
+ * @param queryBuilder Modifier for [SearchQueryBuilder]
+ * @return Finalized search query
+ */
+public fun buildQuery(text: String, queryBuilder: SearchQueryBuilder.() -> Unit = {}): SearchQuery {
+    return SearchQueryBuilder(text).apply(queryBuilder).build()
+}

--- a/core/src/main/kotlin/SearchResult.kt
+++ b/core/src/main/kotlin/SearchResult.kt
@@ -1,0 +1,23 @@
+package com.haroldadmin.lucilla.core
+
+/**
+ * Result of a search query
+ */
+public data class SearchResult(
+    /**
+     * ID of the matched document
+     */
+    val documentId: Int,
+
+    /**
+     * Score of the match. Higher score implies a better
+     * match.
+     */
+    val score: Double,
+
+    /**
+     * The fragment of the search query that matched against
+     * this search result
+     */
+    val matchTerm: String,
+)

--- a/core/src/test/kotlin/SearchQueryTest.kt
+++ b/core/src/test/kotlin/SearchQueryTest.kt
@@ -1,0 +1,28 @@
+package com.haroldadmin.lucilla.core
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+
+class SearchQueryTest : DescribeSpec({
+    describe("buildQuery") {
+        it("should build search query with given text") {
+            val query = buildQuery("foo")
+            query.text shouldBe "foo"
+        }
+
+        it("should pass null selected props by default") {
+            val query = buildQuery("foo")
+            query.selectProps shouldBe null
+        }
+
+        it("should pass given selected props") {
+            val query = buildQuery("foo") { select(Book::title) }
+            query.selectProps shouldBe listOf(Book::title.name)
+        }
+
+        it("should pass empty selected props if none are specified") {
+            val query = buildQuery("foo") { select() }
+            query.selectProps shouldBe emptyList<String>()
+        }
+    }
+})


### PR DESCRIPTION
This PR adds the ability to restrict search queries to specific properties of a document when needed.

- This capability is different than applying `@Ignore` on fields to exclude from indexing.
- This PR also adds the base for a fancy DSL to build queries

Fixes #10